### PR TITLE
Security fix for Prototype Pollution

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -27,8 +27,8 @@ export function extendObjectsOnly<T>(
     Object.keys(source).forEach(key => {
       const value = source[key];
 
-      // prevent infinite loops
-      if (value === target) {
+      // prevent infinite loops and prototype pollution
+      if (value === target || isPrototypePolluted(key)) {
         return;
       }
 
@@ -42,4 +42,12 @@ export function extendObjectsOnly<T>(
   }
 
   return target;
+}
+
+/**
+ * Blacklist certain keys to prevent prototype pollution
+ * @param key Object key to check
+ */
+function isPrototypePolluted(key: string) {
+  return /^__proto__|constructor|prototype$/.test(key);
 }

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -166,6 +166,15 @@ describe('#extendObjectsOnly<any>', () => {
     assert.deepEqual(res, expected);
   });
 
+  it('should prevent prototype pollution', () => {
+    const base = {};
+    const ext = JSON.parse('{"__proto__": {"polluted": true}}');
+
+    const res = extendObjectsOnly<any>(base, ext)
+    assert.deepEqual(res, base);
+    assert.strictEqual(Object.keys(Object.prototype).includes('polluted'), false);
+  });
+
   it('should ignore undefined parameters', () => {
     type T = Record<'a' | 'b' | 'c' | 'd', number>;
     const p1 = { a: 1 };


### PR DESCRIPTION
### :bar_chart: Metadata *

`extend-objects-only` is vulnerable to `Prototype Pollution`.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-extend-objects-only

### :gear: Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as `__proto__`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### :computer: Technical Description *

Fix implemented by not allowing to modify object prototype.

### :bug: Proof of Concept (PoC) *

1. Create the following PoC file:
```JavaScript
// poc.js
var { extendObjectsOnly } = require("extend-objects-only")
const payload = JSON.parse('{"__proto__":{"polluted":"Yes! Its Polluted"}}');
var obj = {}
console.log("Before : " + {}.polluted);
extendObjectsOnly(obj, payload);
console.log("After : " + {}.polluted);
```
2. Execute the following commands in terminal:
```bash
npm i extend-objects-only # Install vulerable package
node poc.js #  Run the PoC
```
3. Check the Output:
```
Before : undefined
After : Yes! Its Polluted
```

### :fire: Proof of Fix (PoF) *

![image](https://user-images.githubusercontent.com/43996156/105576955-899d4980-5d9c-11eb-8948-5f32e783da8c.png)

### +1 User Acceptance Testing (UAT)

* I've executed unit tests.
* After fix the functionality is unaffected.
